### PR TITLE
[SYAL-2897] ClassCastException occurs when switching ContentSourceType control

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,9 +173,21 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>4.0.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.17</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/avispl/symphony/dal/communicator/ppdswave/PhilipsWaveAggregatorCommunicator.java
+++ b/src/main/java/com/avispl/symphony/dal/communicator/ppdswave/PhilipsWaveAggregatorCommunicator.java
@@ -3,7 +3,6 @@
  */
 package com.avispl.symphony.dal.communicator.ppdswave;
 
-import static com.avispl.symphony.dal.util.ControllablePropertyFactory.createPreset;
 import static java.util.stream.Collectors.toList;
 
 import java.util.ArrayList;
@@ -780,8 +779,8 @@ public class PhilipsWaveAggregatorCommunicator extends RestCommunicator implemen
                         processDevicePlaylistContentSources(deviceId, properties, controls, display, playlists);
 
                         String selectedContentSource = deviceSelectedContentSource.get(deviceId);
-                        controls.add(createPreset(Constants.ControlProperties.CONTROL_CONTENT_SOURCE, Arrays.asList(Constants.SourceType.APPLICATION_NAME,
-                                Constants.SourceType.BOOKMARK_NAME, Constants.SourceType.INPUT_NAME, Constants.SourceType.PLAYLIST_NAME), selectedContentSource));
+                        var sourceTypes = Arrays.asList(Constants.SourceType.APPLICATION_NAME, Constants.SourceType.BOOKMARK_NAME, Constants.SourceType.INPUT_NAME, Constants.SourceType.PLAYLIST_NAME);
+                        controls.add(createDropdown(Constants.ControlProperties.CONTROL_CONTENT_SOURCE, sourceTypes, sourceTypes, selectedContentSource));
                         properties.put(Constants.ControlProperties.CONTROL_CONTENT_SOURCE, selectedContentSource);
 
                         processDeviceAppSubscriptions(aggregatedDevice, display);


### PR DESCRIPTION
- Description:
   - Change the type of **ContentSource#ContentSourceType** from **Preset** to **Dropdown**
   - Add the provided dependencies to use for Spring Framework v6 and Java v17 

- Result:
   - Before:
   <img width="596" height="309" alt="image" src="https://github.com/user-attachments/assets/84421940-51db-4b6c-9505-c4b7f5b58e1d" />

   - After:
   <img width="599" height="220" alt="image" src="https://github.com/user-attachments/assets/e718db14-e8d0-493c-b1aa-7735fe89603e" />
